### PR TITLE
Stall AutoPilot trigger on pedal click when there is no drum fill

### DIFF
--- a/BBManagerLean/src/player/songPlayer.cpp
+++ b/BBManagerLean/src/player/songPlayer.cpp
@@ -208,6 +208,7 @@ static uint8_t IntDisable(void);
 static void IntEnable(uint8_t intStatus);
 static void TEMPO_startWithInt(void);
 static void ResetSongPosition(void);
+static void ResetBeatCounter(void);
 #endif
 
 /*****************************************************************************
@@ -812,6 +813,12 @@ static void ResetSongPosition(void) {
     }
     IntEnable(status);
 }
+
+static void ResetBeatCounter(void) {
+    unsigned char status = IntDisable();
+    BeatCounter = 0;
+    IntEnable(status);
+}
 #endif
 
 void SongPlayer_getPlayerStatus(SongPlayer_PlayerStatus *playerStatus,
@@ -961,8 +968,9 @@ int SongPlayer_loadSong(char* file, uint32_t length)
 
         /* Drumfills */
         for (j = 0; j < SongPtr->part[i].nDrumFill; j++) {
-            if (SongPtr->part[i].drumFillIndex[j] < 0)
+            if (SongPtr->part[i].drumFillIndex[j] < 0) {
                 return 0;
+            }
             adjust_trig_length(SongPtr->part[i].drumFillIndex[j]);
         }
         /* Transition Fill */
@@ -1416,6 +1424,10 @@ void SongPlayer_processSong(float ratio, int32_t nTick) {
                 DrumFillStartSyncTick -= DrumFillPickUpSyncTickLength;
 
                 PlayerStatus = DRUMFILL_WAITING_TRIG;
+            }
+            else {
+                // If there is no drum fill in the current part
+                ResetBeatCounter();
             }
             //Extends the section on autopilot
             if(AutopilotAction == 0 && AutopilotCueFill == 0 && APPtr){


### PR DESCRIPTION
Added a function to reset the beat counter.
Reset the beat counter on pedal click on Autopilot when there is no drum fill.
Closes [this](https://github.com/SingularSound/openbbm/issues/6) issue and closes [this](https://github.com/SingularSound/openbbm/issues/9) issue.