### PR TITLE
Issue106

### DIFF
--- a/BBManagerLean/BBManagerLean.pro
+++ b/BBManagerLean/BBManagerLean.pro
@@ -1,6 +1,6 @@
 QT += core gui widgets multimedia network
 
-CONFIG += c++11 release
+CONFIG += c++11 console debug
 
 
 TARGET = BBManagerLean

--- a/BBManagerLean/BBManagerLean.pro
+++ b/BBManagerLean/BBManagerLean.pro
@@ -1,6 +1,6 @@
 QT += core gui widgets multimedia network
 
-CONFIG += c++11 console debug
+CONFIG += c++11 release
 
 
 TARGET = BBManagerLean

--- a/BBManagerLean/src/beatspanel/beatfilewidget.cpp
+++ b/BBManagerLean/src/beatspanel/beatfilewidget.cpp
@@ -1092,6 +1092,7 @@ void BeatFileWidget::updateAPText(bool hasTrans, bool hasMain, bool hasOutro, in
         mp_APBox->hide();
         APBar->hide();
         APText->hide();
+        PostText->hide();
     }
 
     newFill =false;

--- a/BBManagerLean/src/player/songPlayer.cpp
+++ b/BBManagerLean/src/player/songPlayer.cpp
@@ -1188,7 +1188,7 @@ void SongPlayer_processSong(float ratio, int32_t nTick) {
 
 
         // If still waiting for trigger
-        if (TmpMasterPartTick <= DrumFillStartSyncTick) {
+        if ((TmpMasterPartTick + DrumFillPickUpSyncTickLength) <= DrumFillStartSyncTick) {
             TrackPlay(MAIN_LOOP_PTR(CurrPartPtr), MasterTick, TmpMasterPartTick, ratio, 0, MAIN_PART_ID);
 
             // If its the end of the track
@@ -1849,7 +1849,7 @@ static void TrackPlay(MIDIPARSER_MidiTrack *track, int32_t startTick, int32_t en
             return;
     }
     //check if done playing pick up notes to adjust beat counter
-    if(DrumFillPickUpSyncTickLength > 0 && track->event[track->index].tick >= 0){
+    if(DrumFillPickUpSyncTickLength > 0 && track->event[track->index].tick >= 0 && PlayerStatus != DRUMFILL_WAITING_TRIG){
         TmpMasterPartTick -=DrumFillPickUpSyncTickLength;//This avoids displacing the beat
         DrumFillPickUpSyncTickLength = 0;
         if(playingPickUp){//if it played pick up notes, on pedal press pick up notes might not play

--- a/BBManagerLean/src/player/songPlayer.cpp
+++ b/BBManagerLean/src/player/songPlayer.cpp
@@ -1097,7 +1097,7 @@ void SongPlayer_processSong(float ratio, int32_t nTick) {
                         MAIN_LOOP_PTR(CurrPartPtr)->barLength);
 
                 if(TRANS_FILL_PTR(CurrPartPtr)->nTick > TRANS_FILL_PTR(CurrPartPtr)->barLength &&
-                   !(MasterTick/(SongPlayer_getbarLength() / TRANS_FILL_PTR(CurrPartPtr)->timeSigNum) >= TRANS_FILL_PTR(CurrPartPtr)->timeSigNum)){
+                   !(MasterTick/(SongPlayer_getbarLength() / TRANS_FILL_PTR(CurrPartPtr)->timeSigNum) >= TRANS_FILL_PTR(CurrPartPtr)->timeSigNum) && AutopilotCueFill){
                     //longer than 1 bar trans fill when main loop is on the first bar
                    TranFillStopSyncTick *= TRANS_FILL_PTR(CurrPartPtr)->nTick / TRANS_FILL_PTR(CurrPartPtr)->barLength;
                 }


### PR DESCRIPTION
Fixed here:
-Transfill should stop on long pedal release.
-Fills should not get skipped even if shorter than 1 beat.

Note: always change the 5th fill AP settings on load due to #115 

Provided song by user where this happens:
[song.zip](https://github.com/SingularSound/openbbm/files/5176369/song.zip)
