### PR TITLE
Adding check on StopSong Method

### DIFF
--- a/BBManagerLean/src/player/songPlayer.cpp
+++ b/BBManagerLean/src/player/songPlayer.cpp
@@ -1870,7 +1870,7 @@ static int32_t CalculateStartBarSyncTick(uint32_t tickPos,
 }
 
 static void StopSong(void) {
-    if(PedalPresswDrumFillFlag == 1){
+    if(PedalPresswDrumFillFlag == 1 && MultiTapCounter == 0){
         MasterTick = 0;
         ResetBeatCounter();
         PedalPresswDrumFillFlag = 0;


### PR DESCRIPTION
This PR is for the  #137 caused by the main was playing a drumfill on the next bar and received a multi tap signal.